### PR TITLE
Use Net Standard 2.0

### DIFF
--- a/src/Com.Courier.Test/Com.Courier.Test.csproj
+++ b/src/Com.Courier.Test/Com.Courier.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Com.Courier.Test</AssemblyName>
     <RootNamespace>Com.Courier.Test</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Com.Courier/Com.Courier.csproj
+++ b/src/Com.Courier/Com.Courier.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Com.Courier</AssemblyName>
     <PackageId>Com.Courier</PackageId>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
We need to use this with .NET Framework and .NET Core apps. 
This will allow both to use the library. 